### PR TITLE
fix: Load zen-drop-link when window is already initialized

### DIFF
--- a/file.uc.js
+++ b/file.uc.js
@@ -303,13 +303,15 @@ class ZenSplitViewLinkDrop {
 
 (function () {
   if (!globalThis.zenDropLinkInstance) {
-    window.addEventListener(
-      "load",
-      () => {
-        globalThis.zenDropLinkInstance = new ZenSplitViewLinkDrop();
-        globalThis.zenDropLinkInstance.init();
-      },
-      { once: true },
-    );
+    const init = () => {
+      globalThis.zenDropLinkInstance = new ZenSplitViewLinkDrop();
+      globalThis.zenDropLinkInstance.init();
+    };
+
+    if (document.readyState === "complete") {
+      init();
+    } else {
+      window.addEventListener("load", init, { once: true });
+    }
   }
 })();


### PR DESCRIPTION
Sine v2.3 allows JS scripts to apply without having to restart the browser. Despite this, this mod previously would wait for the init window listener to call it's initialization code, which would work on browser start (before the window had initialized), but wouldn't the moment it was installed. This pull request loads the mod instantly if the window is already in an initialized state.